### PR TITLE
Enable Async configuration added to CCDAParsingAPIConfiguration class.

### DIFF
--- a/src/main/java/org/sitenv/ccdaparsing/configuration/CCDAParsingAPIConfiguration.java
+++ b/src/main/java/org/sitenv/ccdaparsing/configuration/CCDAParsingAPIConfiguration.java
@@ -2,8 +2,10 @@ package org.sitenv.ccdaparsing.configuration;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @ComponentScan(basePackages = {"org.sitenv.ccdaparsing"})
 @Configuration
+@EnableAsync
 public class CCDAParsingAPIConfiguration {
 }


### PR DESCRIPTION
CCDAParserAPI.java API's 'parseCCDA2_1' method has async processors for each section to parse respective section(Medication, Problem... etc.) data.

But in the configuration file CCDAParsingAPIConfiguration.java async feature is not enabled.
Due to this all the processors linear execution takes Hugh amount of time in processing.
i.e. In scenarios where CCDA's of 7 to 8 MB size is taking 15 to 17 mints to parse.

Adding '@EnableAsync' configuration into CCDAParsingAPIConfiguration.java file improves time by 50% in previous example.